### PR TITLE
CRAYSAT-1543: Update vendored hpc-shastarelm-release library

### DIFF
--- a/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
+++ b/vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh
@@ -5,9 +5,9 @@
 : "${PACKAGING_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/packaging-tools:0.12.3}"
 : "${RPM_TOOLS_IMAGE:=arti.hpc.amslabs.hpecorp.net/internal-docker-stable-local/rpm-tools:1.0.0}"
 : "${SKOPEO_IMAGE:=arti.hpc.amslabs.hpecorp.net/quay-remote/skopeo/stable:v1.4.1}"
-: "${CRAY_NEXUS_SETUP_IMAGE:=artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1}"
+: "${CRAY_NEXUS_SETUP_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cray-nexus-setup:0.7.1}"
 : "${ARTIFACTORY_HELPER_IMAGE:=arti.hpc.amslabs.hpecorp.net/dst-docker-master-local/arti-helper:latest}"
-: "${CFS_CONFIG_UTIL_IMAGE:=artifactory.algol60.net/csm-docker/stable/cfs-config-util:3.1.0}"
+: "${CFS_CONFIG_UTIL_IMAGE:=arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:3.3.0}"
 
 # Prefer to use docker, but for environments with podman
 if [[ "${USE_PODMAN_NOT_DOCKER:-"no"}" == "yes" ]]; then


### PR DESCRIPTION
## Summary and Scope

Update the vendored hpc-shastarelm-release library to the latest master commit [da7b39187520dbcffc0cc27abe03ca8783b26cf3](https://github.hpe.com/hpe/hpc-shastarelm-release/tree/da7b39187520dbcffc0cc27abe03ca8783b26cf3) in order to pull in the 3.3.0 version of the `cfs-config-util` container image.

## Issues and Related PRs

* Resolves [CRAYSAT-1543](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1543)

## Testing

### Tested on:

  * `surtur`

### Test description:

- Install updated product stream on surtur and run some test `cfs-config-util` commands using `update-mgmt-ncn-cfs-config.sh` to test new 3.3.0 functionality.

## Risks and Mitigations

N/A


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

